### PR TITLE
Update the editorial board of configuration management and graduate student

### DIFF
--- a/_data/areas/confManagement/board.yml
+++ b/_data/areas/confManagement/board.yml
@@ -109,3 +109,11 @@ members:
   twitter:
   from: 2022
   until: 0
+
+- name: Chengcheng (CC) Xiang
+  affiliation: Meta
+  webpage: https://evonx.github.io/
+  orcid:
+  twitter:
+  from: 2022
+  until: 0

--- a/_data/areas/students/board.yml
+++ b/_data/areas/students/board.yml
@@ -70,14 +70,6 @@ members:
   from: 2021
   until: 0
 
-- name: Chengcheng Xiang
-  affiliation: UC San Diego
-  webpage: https://evonx.github.io/
-  orcid: 
-  twitter: 
-  from: 2021
-  until: 0
-
 - name: Chinmay Kulkarni
   affiliation: University of Utah
   webpage: https://www.chinmayk.net/
@@ -278,3 +270,10 @@ members:
   from: 2021
   until: 0
 
+- name: Jinghao Jia
+  affiliation: University of Illinois at Urbana-Champaign
+  webpage:
+  orcid:
+  twitter:
+  from: 2022
+  until: 0


### PR DESCRIPTION
* Move Chengcheng (CC) Xiang to the editorial board of configuration management from the student editorial board
   * CC graduated from UCSD a year ago and joined Meta as a research scientist
* Add Jinghao Jia, a PhD student from the University of Illinois, to the student editorial board to replace CC.
* Let's merge this PR before the end of this month as both CC and Jinghao are reviewing a new paper submission: https://openreview.net/forum?id=-0sywUv8ryL, and it's better to let the authors know that they are in our team given the open reviews.

ps, many students on the student editorial board are no longer students so we may need to find a time to update it.