### PR TITLE
 Make links more visibles

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -21,9 +21,10 @@ $link-color: #000000;
 $text-color: rgb(70, 70, 70);
 $primary-color: $green;
 $primary-color-light:#baefb6; 
+$link-color-hover: $primary-color;
 
 a {
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 // Not sure how to rename


### PR DESCRIPTION
The link color was black, due to the template's CSS reset, which made
them hard to distinguish from normal text. This commit makes the links
green (the theme's color) to make them easier to distinguish

Before:

<img width="617" alt="Screenshot 2023-06-10 at 18 51 11" src="https://github.com/jsysresearch/website/assets/23420125/8fd863a6-a9e1-45f5-9e38-846eb86705d0">

After:
<img width="596" alt="Screenshot 2023-06-10 at 19 24 49" src="https://github.com/jsysresearch/website/assets/23420125/a4e84eef-16d5-48f5-806f-6e4a92cfbfb1">

(This PR can be rebased on top of #31)
